### PR TITLE
Add Travis CI fakeroot package addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: rust
 cache: cargo
 dist: trusty
 
+addons:
+  apt:
+    packages:
+      - fakeroot
+
 env:
   global:
     - PROJECT_NAME=algorithmia


### PR DESCRIPTION
the release failed due to this error in Travis:
```
ci/prepare_deploy.sh: line 58: fakeroot: command not found
```

This PR manually adds the missing command to the Travis build