### PR TITLE
Add Windows check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -170,6 +170,14 @@ handle_command_line_args() {
     local _help=false
     local _disable_sudo=false
 
+    case "$(uname -s)" in
+        MINGW* | MSYS* | CYGWIN*)
+            echo "Sorry, but this script doesn't currently support Windows. You can find the Windows install instructions here: https://algorithmia.com/developers/clients/cli#installing-the-algorithmia-cli"
+            return
+            ;;
+        *)
+    esac
+
     local _arg
     for _arg in "$@"; do
         case "${_arg%%=*}" in


### PR DESCRIPTION
Adds a simple check to notify users that Windows (MINGW/Cygwin) isn't presently supported by the install script.

![](https://i.imgur.com/VcXSSeh.png)


EDIT: Forgot to mention that the main motivation behind this is the fact that I got a misleading 404 curl error when trying to run the install.sh file on my Windows machine (using Git Bash). The script assumes that the user is using a *nix system, and so only handles the *.tar.gz scenario when crafting the url (see "RELEASE URL" output in screenshot below) and installing the program. I started coding a solution to support Windows, but some quick research on MINGW and Cygwin made it look like a pretty time-consuming task, which I can't currently afford.

Output from current version of code with verbose flag enabled (and one output line, "RELEASE URL" added):
![](https://i.imgur.com/Qozglbw.png)


Thanks,

-Vlad