### PR TITLE
Optionally Create /usr/local/bin If Nonexistent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -249,6 +249,7 @@ install_cli() {
 
     # copy to $_prefix/bin
     echo_verbose "installing 'algo'..."
+    maybe_sudo mkdir -p $_prefix/bin/
     maybe_sudo cp $tmpdir/algo $_prefix/bin/
     migrate_config
 


### PR DESCRIPTION
Resolves [UXENG-1960](https://algorithmia.atlassian.net/browse/UXENG-1960). 

`/usr/local/bin` is already present in $PATH for Mac users, but doesn't necessarily exist. Verified on Pauline's Macbook that this addresses the issue.